### PR TITLE
Fix berserked targeting after using Hermes

### DIFF
--- a/FreeEnt/generator.py
+++ b/FreeEnt/generator.py
@@ -185,6 +185,7 @@ F4C_FILES = '''
     scripts/blank_textbox_fix.f4c
     scripts/cycle_party_leader.f4c
     scripts/item_delivery_quantity.f4c
+    scripts/fix_hermes_berserk.f4c
 '''
 
 BINARY_PATCHES = {

--- a/FreeEnt/scripts/fix_hermes_berserk.f4c
+++ b/FreeEnt/scripts/fix_hermes_berserk.f4c
@@ -1,0 +1,20 @@
+msfpatch {
+    .addr $03ae81
+        jsr $_FixTargetAllHermes
+    
+    .addr $03fee7
+    FixTargetAllHermes:
+        lda #$04          // Berserked status bit
+        ldx #$03
+    %StatusLoop:
+        cmp $2683,x       // Actor status effects
+        beq $+NoAllTarget
+        dex
+        bpl $-StatusLoop
+        lda $1802         // Current battle background
+        bit #$10          // Zeromus battle background, handles Black Hole with berserk queued.
+        bne $+NoAllTarget
+        lda $26d2         // Current actor subcommand. What we wrote over.
+    %NoAllTarget:
+        rts
+}

--- a/FreeEnt/scripts/fix_hermes_berserk.f4c
+++ b/FreeEnt/scripts/fix_hermes_berserk.f4c
@@ -1,20 +1,15 @@
 msfpatch {
     .addr $03ae81
-        jsr $_FixTargetAllHermes
+        jsr $_FixTargetSwoonedHermes
     
     .addr $03fee7
-    FixTargetAllHermes:
-        lda #$04          // Berserked status bit
-        ldx #$03
-    %StatusLoop:
-        cmp $2683,x       // Actor status effects
-        beq $+NoAllTarget
-        dex
-        bpl $-StatusLoop
-        lda $1802         // Current battle background
-        bit #$10          // Zeromus battle background, handles Black Hole with berserk queued.
-        bne $+NoAllTarget
-        lda $26d2         // Current actor subcommand. What we wrote over.
-    %NoAllTarget:
+    FixTargetSwoonedHermes:
+        lda $26d1
+        cmp #$c2
+        bne $+NotLifeAll
+        lda $26d2
+        rts
+    %NotLifeAll:
+        tya
         rts
 }


### PR DESCRIPTION
This fixes a bug where berserked party members can target swooned enemies if they use the Hermes item before being berserked. We hook into the battle command execution routine at $03AE81, where the current actor's subcommand is loaded and compared to $BA, which is used for both the Hermes item and a "Life All" enemy spell. If the value is $BA, a "can hit swooned" flag is set (also used for things like Life potions.) Our code checks if the actor command is $C2, a monster white magic action. If the command is $C2, we load the subcommand, exit, and proceed with the comparison. If not $C2, we transfer Y (which will always hold $FFFF from a previous loop in this path) to A.

```
let Y = $FFFF
...
let A = actor_command
if A == MONSTER_WHITE_MAGIC_COMMAND:
    let A = actor_subcommand
    return A
else:
    let A = Y & 0x00FF
    return A
```
This works because the Life All command is only used during the Zeromus cutscene (when Palom and Porom revive the party.) So the subcommand can never be $BA except in this cutscene and therefore other enemy healing actions won't improperly target swooned characters. When a character is berserked, their command will never be $C2, the monster white magic command. Y = $FFFF is another invariant we can depend on, there are no branches between the decrement that sets it and our code.

Another avenue worth investigating is hooking into the vanilla "select berserk target" routine around $03ACA3 which is called during a "queue auto actions routine" that only loops through the five player characters. The former routine initializes some character data including setting the "main" command to zero. It may be possible to safely zero out the subcommand here as well (perhaps if the character is also not charmed.) But I am unsure if this may have other side effects. Could also look into zeroing out the subcommand when berserked.